### PR TITLE
Unify hero title typography

### DIFF
--- a/assets/css/extended/research-blog.css
+++ b/assets/css/extended/research-blog.css
@@ -185,8 +185,10 @@ button#theme-toggle svg {
 
 .research-hero h1 em {
   color: var(--accent);
-  font-family: var(--font-serif);
-  font-weight: 400;
+  font-family: inherit;
+  font-size: inherit;
+  font-style: normal;
+  font-weight: inherit;
 }
 
 .research-hero__dek {


### PR DESCRIPTION
## What changed

- Changed “Alignment” in the homepage hero to inherit the exact font family, size, weight, and upright style used by “Full Contact.”
- Preserved the green accent color as the only distinction between the two lines.

## Why

Using both a contrasting color and italic serif type made the title feel over-styled. A single color contrast keeps the hierarchy while making the headline more direct and contemporary.

## Validation

- Production Hugo build completed successfully in an isolated output directory.
- `git diff --check`
- Verified at a 390px viewport with no horizontal overflow.
- Confirmed both title lines resolve to the same font family, `66.3px` size, `680` weight, and normal style on mobile.

## Dependency

This is a stacked PR targeting `codex/research-blog-redesign` and should be merged after or into #1.
