### PR TITLE
Follow system color scheme and improve theme toggle access

### DIFF
--- a/assets/css/extended/research-blog.css
+++ b/assets/css/extended/research-blog.css
@@ -1,5 +1,6 @@
 /* Editorial system for hackbot.dad --------------------------------------- */
 :root {
+  color-scheme: light;
   --theme: #f7f6f1;
   --entry: #f7f6f1;
   --primary: #18231e;
@@ -23,7 +24,28 @@
   --radius: 3px;
 }
 
+/* Follow the visitor's system preference until they choose a theme. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+    --theme: #111713;
+    --entry: #141c17;
+    --primary: #edf1ed;
+    --secondary: #a4afa7;
+    --tertiary: #344139;
+    --content: #d8ded9;
+    --border: #303b34;
+    --code-bg: #222c26;
+    --code-block-bg: #0a0f0c;
+    --accent: #72c69f;
+    --accent-soft: #1d382b;
+    --accent-contrast: #0d1711;
+  }
+}
+
+:root[data-theme="dark"],
 .dark {
+  color-scheme: dark;
   --theme: #111713;
   --entry: #141c17;
   --primary: #edf1ed;
@@ -37,6 +59,8 @@
   --accent-soft: #1d382b;
   --accent-contrast: #0d1711;
 }
+
+:root[data-theme="light"] { color-scheme: light; }
 
 html {
   scroll-behavior: smooth;
@@ -98,19 +122,33 @@ a { text-underline-offset: 0.18em; }
 
 button#theme-toggle {
   display: grid;
-  width: 32px;
-  height: 32px;
+  width: 38px;
+  height: 38px;
   margin: 0;
   padding: 0;
+  border: 1px solid transparent;
+  border-radius: 50%;
   place-items: center;
   color: var(--secondary);
+  background: transparent;
   line-height: 1;
+  transition: color 160ms ease, background-color 160ms ease;
 }
 
 .logo-switches {
   display: flex;
   align-items: center;
-  margin: 0 0 0 8px;
+  margin: 0 var(--gap) 0 18px;
+}
+
+button#theme-toggle:hover {
+  color: var(--primary);
+  background: var(--accent-soft);
+}
+
+button#theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 button#theme-toggle svg {
@@ -119,7 +157,11 @@ button#theme-toggle svg {
   height: 18px;
 }
 
-#menu { gap: 28px; }
+#menu {
+  gap: 28px;
+  margin-right: 0;
+  margin-left: auto;
+}
 #menu li + li { margin: 0; }
 
 #menu a {
@@ -859,10 +901,11 @@ button#theme-toggle svg {
   .nav { flex-wrap: nowrap; }
   .logo, #menu { margin: 0 16px; }
   .logo a { font-size: 15px; white-space: nowrap; }
-  .logo-switches { margin-left: 4px; }
-  #menu { gap: 15px; margin-left: auto; overflow: visible; }
+  .logo-switches { margin: 0 16px 0 10px; }
+  #menu { gap: 15px; margin-right: 0; margin-left: auto; overflow: visible; }
   #menu li:first-child { display: none; }
   #menu a { font-size: 12px; }
+  button#theme-toggle { width: 44px; height: 44px; }
 
   .research-hero {
     grid-template-columns: 1fr;

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,3 +1,53 @@
+{{/* Keep the visible control, explicit override, and live OS preference in sync. */}}
+<script>
+(function () {
+  const root = document.documentElement;
+  const toggle = document.getElementById('theme-toggle');
+  const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+
+  if (!toggle) return;
+
+  const savedTheme = function () {
+    try {
+      const theme = localStorage.getItem('pref-theme');
+      return theme === 'light' || theme === 'dark' ? theme : null;
+    } catch (_) {
+      return null;
+    }
+  };
+
+  const updateControl = function (theme) {
+    const isDark = theme === 'dark';
+    const label = 'Switch to ' + (isDark ? 'light' : 'dark') + ' color scheme';
+    toggle.setAttribute('aria-label', label);
+    toggle.setAttribute('aria-pressed', String(isDark));
+    toggle.title = label + ' (Alt + T)';
+  };
+
+  updateControl(document.body.classList.contains('dark') ? 'dark' : 'light');
+
+  toggle.addEventListener('click', function () {
+    const nextTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+    root.dataset.theme = nextTheme;
+    updateControl(nextTheme);
+  });
+
+  const followSystemTheme = function (event) {
+    if (savedTheme()) return;
+    const theme = event.matches ? 'dark' : 'light';
+    root.removeAttribute('data-theme');
+    document.body.classList.toggle('dark', event.matches);
+    updateControl(theme);
+  };
+
+  if (systemTheme.addEventListener) {
+    systemTheme.addEventListener('change', followSystemTheme);
+  } else if (systemTheme.addListener) {
+    systemTheme.addListener(followSystemTheme);
+  }
+})();
+</script>
+
 {{/* MathJax: preserve TeX support without changing article typography. */}}
 <script>
 window.MathJax = {

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,6 +1,18 @@
 {{/* Deployment verification */}}
 {{ if eq hugo.Environment "production" }}{{ with getenv "GITHUB_SHA" }}<meta name="build-id" content="{{ . }}">{{ end }}{{ end }}
 
+{{/* Apply an explicit visitor choice before the page paints. Without one, CSS follows the OS preference. */}}
+<script>
+(function () {
+  try {
+    const theme = localStorage.getItem('pref-theme');
+    if (theme === 'light' || theme === 'dark') {
+      document.documentElement.dataset.theme = theme;
+    }
+  } catch (_) {}
+})();
+</script>
+
 {{/* Icons and browser chrome */}}
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,124 @@
+{{- /* Preserve PaperMod's theme behavior while placing the control after the main navigation. */}}
+<script>
+(function () {
+    const defaultTheme = '{{ site.Params.defaultTheme | default "auto" }}';
+    let savedTheme = null;
+    {{- if (not site.Params.disableThemeToggle) }}
+    try {
+        const preference = localStorage.getItem('pref-theme');
+        if (preference === 'light' || preference === 'dark') savedTheme = preference;
+    } catch (_) {}
+    {{- end }}
+
+    const useDarkTheme = savedTheme === 'dark' || (
+        savedTheme === null && (
+            defaultTheme === 'dark' ||
+            (defaultTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        )
+    );
+    document.body.classList.toggle('dark', useDarkTheme);
+})();
+</script>
+
+<header class="header">
+    <nav class="nav" aria-label="Primary navigation">
+        <div class="logo">
+            {{- $labelText := (site.Params.label.text | default site.Title) }}
+            {{- if site.Title }}
+            <a href="{{ "" | absLangURL }}" accesskey="h" title="{{ $labelText }} (Alt + H)">
+                {{- if site.Params.label.icon }}
+                {{- $img := resources.Get site.Params.label.icon }}
+                {{- if $img }}
+                    {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
+                    {{- if hugo.IsExtended -}}
+                        {{- $processableFormats = $processableFormats | append "webp" -}}
+                    {{- end -}}
+                    {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) }}
+                    {{- if and (in $processableFormats $img.MediaType.SubType) (eq $prod true)}}
+                        {{- if site.Params.label.iconHeight }}
+                            {{- $img = $img.Resize (printf "x%d" site.Params.label.iconHeight) }}
+                        {{ else }}
+                            {{- $img = $img.Resize "x30" }}
+                        {{- end }}
+                    {{- end }}
+                    <img src="{{ $img.Permalink }}" alt="" height="{{- site.Params.label.iconHeight | default "30" -}}">
+                {{- else }}
+                    <img src="{{- site.Params.label.icon | absURL -}}" alt="" height="{{- site.Params.label.iconHeight | default "30" -}}">
+                {{- end -}}
+                {{- else if hasPrefix site.Params.label.iconSVG "<svg" }}
+                    {{ site.Params.label.iconSVG | safeHTML }}
+                {{- end -}}
+                {{- $labelText -}}
+            </a>
+            {{- end }}
+        </div>
+
+        {{- $currentPage := . }}
+        <ul id="menu">
+            {{- range site.Menus.main }}
+            {{- $menuItemURL := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL)) | absLangURL }}
+            {{- $pageURL := $currentPage.Permalink | absLangURL }}
+            {{- $isSearch := eq (site.GetPage .KeyName).Layout `search` }}
+            <li>
+                <a href="{{ .URL | absLangURL }}" title="{{ .Title | default .Name }}{{- cond $isSearch (" (Alt + /)" | safeHTMLAttr) ("" | safeHTMLAttr) }}"
+                    {{- cond $isSearch (" accesskey=/" | safeHTMLAttr) ("" | safeHTMLAttr) }}>
+                    <span {{- if eq $menuItemURL $pageURL }} class="active" {{- end }}>
+                        {{- .Pre }}{{ .Name }}{{ .Post -}}
+                    </span>
+                    {{- if (findRE "://" .URL) }}&nbsp;
+                    <svg fill="none" shape-rendering="geometricPrecision" stroke="currentColor" stroke-linecap="round"
+                        stroke-linejoin="round" stroke-width="2.5" viewBox="0 0 24 24" height="12" width="12" aria-hidden="true">
+                        <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"></path>
+                        <path d="M15 3h6v6"></path>
+                        <path d="M10 14L21 3"></path>
+                    </svg>
+                    {{- end }}
+                </a>
+            </li>
+            {{- end }}
+        </ul>
+
+        <div class="logo-switches">
+            {{- if (not site.Params.disableThemeToggle) }}
+            <button id="theme-toggle" type="button" accesskey="t" title="Toggle color scheme (Alt + T)" aria-label="Toggle color scheme">
+                <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
+                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                </svg>
+                <svg id="sun" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
+                    fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="12" cy="12" r="5"></circle>
+                    <line x1="12" y1="1" x2="12" y2="3"></line>
+                    <line x1="12" y1="21" x2="12" y2="23"></line>
+                    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                    <line x1="1" y1="12" x2="3" y2="12"></line>
+                    <line x1="21" y1="12" x2="23" y2="12"></line>
+                    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                </svg>
+            </button>
+            {{- end }}
+
+            {{- $lang := .Lang }}
+            {{- with site.Home.Translations }}
+            <ul class="lang-switch">
+                {{- range . -}}
+                {{- if ne $lang .Lang }}
+                <li>
+                    <a href="{{- .Permalink -}}" title="{{ .Language.Params.languageAltTitle | default (.Language.LanguageName | emojify) | default (.Lang | title) }}"
+                        aria-label="{{ .Language.LanguageName | default (.Lang | title) }}">
+                        {{- if (and site.Params.displayFullLangName (.Language.LanguageName)) }}
+                            {{- .Language.LanguageName | emojify -}}
+                        {{- else }}
+                            {{- .Lang | title -}}
+                        {{- end -}}
+                    </a>
+                </li>
+                {{- end -}}
+                {{- end }}
+            </ul>
+            {{- end }}
+        </div>
+    </nav>
+</header>


### PR DESCRIPTION
## What changed

- follow `prefers-color-scheme` by default with the site's custom light and dark palettes
- preserve an explicit light/dark selection across reloads and react to live OS theme changes until the visitor chooses
- move the theme toggle after Talks in the visual and keyboard order
- add dynamic accessible labels, pressed state, focus styling, and a 44px mobile touch target

## Why

The existing `auto` setting depended primarily on a one-time script and placed the toggle beside the site title. This makes the browser preference the CSS default while keeping the manual override easy to find and operate on desktop and mobile.

## Validation

- `hugo --destination <temporary directory> --minify`
- `git diff --check`
- responsive browser checks at 1440px and 390px on the homepage, Writing, Research, and a post with a table of contents and footnotes
- verified a fresh dark system preference, the manual light toggle, and persistence after reload
