### PR TITLE
Feature ScopeJudge research

### DIFF
--- a/content/papers/_index.md
+++ b/content/papers/_index.md
@@ -6,7 +6,11 @@ summary: "Shane Caldwell's research papers and publications"
 description: "Research on autonomous security agents, oversight, and evaluation."
 ---
 
-{{< paper title="PentestJudge: Judging Agent Behavior Against Operational Requirements" authors="Shane Caldwell, Max Harley, Michael Kouremetis, Vincent Abruzzo, Will Pearce" date="August 4th, 2025" url="https://arxiv.org/abs/2508.02921" featured="true" >}}
+{{< paper title="ScopeJudge: Cost-Aware Pre-Execution Gating for Offensive Security Agents" authors="Shane Caldwell, Max Harley, Ads Dawson, Michael Kouremetis, Vincent Abruzzo, Will Pearce" date="July 8th, 2026" url="https://arxiv.org/abs/2607.07774" featured="true" >}}
+We introduce ScopeJudge, a benchmark and cost-aware pre-execution gate for catching out-of-scope tool calls before offensive security agents execute them.
+{{< /paper >}}
+
+{{< paper title="PentestJudge: Judging Agent Behavior Against Operational Requirements" authors="Shane Caldwell, Max Harley, Michael Kouremetis, Vincent Abruzzo, Will Pearce" date="August 4th, 2025" url="https://arxiv.org/abs/2508.02921" >}}
 We introduce PentestJudge, a system for evaluating the operations of penetration testing agents.
 {{< /paper >}}
 

--- a/content/papers/_index.md
+++ b/content/papers/_index.md
@@ -7,7 +7,7 @@ description: "Research on autonomous security agents, oversight, and evaluation.
 ---
 
 {{< paper title="ScopeJudge: Cost-Aware Pre-Execution Gating for Offensive Security Agents" authors="Shane Caldwell, Max Harley, Ads Dawson, Michael Kouremetis, Vincent Abruzzo, Will Pearce" date="July 8th, 2026" url="https://arxiv.org/abs/2607.07774" featured="true" >}}
-We introduce ScopeJudge, a benchmark and cost-aware pre-execution gate for catching out-of-scope tool calls before offensive security agents execute them.
+We introduce a benchmark of 4,897 offensive-security agent tool calls to evaluate how well runtime monitors detect out-of-scope actions as the amount of available context varies.
 {{< /paper >}}
 
 {{< paper title="PentestJudge: Judging Agent Behavior Against Operational Requirements" authors="Shane Caldwell, Max Harley, Michael Kouremetis, Vincent Abruzzo, Will Pearce" date="August 4th, 2025" url="https://arxiv.org/abs/2508.02921" >}}

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -95,7 +95,7 @@ params:
     date: "July 2026"
     url: "https://arxiv.org/abs/2607.07774"
     label: "Latest research"
-    summary: "A benchmark and cost-aware pre-execution gate for catching out-of-scope tool calls before offensive security agents execute them."
+    summary: "A benchmark of 4,897 offensive-security agent tool calls for evaluating how well runtime monitors detect out-of-scope actions as the amount of available context varies."
 
   assets:
     disableHLJS: false

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -91,11 +91,11 @@ params:
     - path: "/writing/pretraining-at-home"
 
   latestPaper:
-    title: "PentestJudge: Judging Agent Behavior Against Operational Requirements"
-    date: "August 2025"
-    url: "https://arxiv.org/abs/2508.02921"
+    title: "ScopeJudge: Cost-Aware Pre-Execution Gating for Offensive Security Agents"
+    date: "July 2026"
+    url: "https://arxiv.org/abs/2607.07774"
     label: "Latest research"
-    summary: "A system for evaluating whether penetration-testing agents satisfy operational requirements, not merely whether their final answers look correct."
+    summary: "A benchmark and cost-aware pre-execution gate for catching out-of-scope tool calls before offensive security agents execute them."
 
   assets:
     disableHLJS: false


### PR DESCRIPTION
## Summary

- add ScopeJudge as the newest paper on the Research page
- move the featured research treatment from PentestJudge to ScopeJudge
- update the homepage latest-research card with the new paper

## Why

ScopeJudge is now publicly available on arXiv and should be the site's featured research.

## Validation

- `hugo --cleanDestinationDir --minify`
- `git diff --check`
- confirmed the generated homepage and Research page contain the correct title, arXiv URL, authors, date, summary, and featured state