### PR TITLE
Add homepage social profile links

### DIFF
--- a/assets/css/extended/research-blog.css
+++ b/assets/css/extended/research-blog.css
@@ -248,6 +248,38 @@ button#theme-toggle svg {
   margin-top: 32px;
 }
 
+.research-hero__socials {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.research-hero__socials a {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  place-items: center;
+  color: var(--secondary);
+  transition: color 160ms ease, background-color 160ms ease;
+}
+
+.research-hero__socials a:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.research-hero__socials a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.research-hero__socials svg {
+  width: 29px;
+  height: 29px;
+}
+
 .text-link {
   display: inline-flex;
   gap: 10px;

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -116,10 +116,15 @@ params:
       
 
   socialIcons:
+    - name: x
+      title: X
+      url: "https://x.com/shanejcaldwell"
+    - name: linkedin
+      title: LinkedIn
+      url: "https://www.linkedin.com/in/caldwellshane/"
     - name: github
+      title: GitHub
       url: "https://github.com/SJCaldwell"
-    - name: twitter
-      url: "https://twitter.com/shncldwll"
     - name: rss
       url: "index.xml"
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,15 @@
       <a class="text-link" href="/papers/">View research <span aria-hidden="true">→</span></a>
       <a class="text-link text-link--quiet" href="https://dreadnode.io/">Dreadnode <span aria-hidden="true">↗</span></a>
     </div>
+    <nav class="research-hero__socials" aria-label="Social profiles">
+      {{- range .Site.Params.socialIcons }}
+        {{- if in (slice "x" "linkedin" "github") .name }}
+      <a href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer me" aria-label="{{ .title }}" title="{{ .title }}">
+        {{- partial "svg.html" . }}
+      </a>
+        {{- end }}
+      {{- end }}
+    </nav>
   </div>
   <div class="research-hero__portrait">
     <img src="/profile.jpg" alt="Shane Caldwell speaking at a conference" width="240" height="240">


### PR DESCRIPTION
## Summary

- add X, LinkedIn, and GitHub icons beneath the homepage hero links
- update the X profile to the new username
- add accessible labels, hover/focus styling, and mobile-friendly touch targets

## Verification

- `hugo --cleanDestinationDir --minify`
- `git diff --check`
- visually checked desktop, dark mode, and a 390px mobile viewport